### PR TITLE
A bat unit is not necessarily a drupal bat unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To display calendars and dates we use the following libraries:
 ## Configuration
  - Enable at least the BAT, BAT Unit, BAT Event and BAT Event UI modules (if you want to view events on a calendar)
  - For BAT Event UI to work you need the BAT API module which is in a separate project - http://drupal.org/project/bat_api - *you need branch 7.x-2.x*
- - Make sure to set the jQuery for the admin theme to at least 1.10 by visiting *admin/config/development/jquery_update*
+ - Make sure to set the jQuery for the admin theme to at least 1.10 by visiting *admin/config/development/jquery_update* or your calendars will not appear
 
 ## Setup
 

--- a/modules/bat_event/bat_event.admin.inc
+++ b/modules/bat_event/bat_event.admin.inc
@@ -253,19 +253,23 @@ function bat_event_edit_form($form, &$form_state, $event) {
   $form_state['bat_event'] = $event;
   field_attach_form('bat_event', $event, $form, $form_state);
 
-  isset($form['event_unit_reference']['#language']) ? $language = $form['event_unit_reference']['#language'] : $language = LANGUAGE_NONE;
+  $event_type = bat_event_type_load($event->type);
+  // Construct target entity reference field name using this event type's target entity type.
+  $target_field_name = 'event_' . $event_type->target_entity_type . '_reference';
 
-  $unitid = '';
-  if (isset($_GET['unitid'])) {
-    $unitid = check_plain($_GET['unitid']);
+  isset($form[$target_field_name]['#language']) ? $language = $form[$target_field_name]['#language'] : $language = LANGUAGE_NONE;
 
-    if ($unit = bat_unit_load($unitid)) {
-      $form['event_unit_reference'][$language][0]['target_id']['#default_value'] = $unit->name . ' (' . $unit->unit_id . ')';
+  $targetid = '';
+  if (isset($_GET['targetid'])) {
+    $targetid = check_plain($_GET['targetid']);
+
+    if ($target_entity = entity_load_single($event_type->target_entity_type, $targetid)) {
+      $form[$target_field_name][$language][0]['target_id']['#default_value'] = $target_entity->name . ' (' . $targetid . ')';
     }
   }
 
   // The unit reference value should be mandatory.
-  $form['event_unit_reference'][$language][0]['target_id']['#required'] = TRUE;
+  $form[$target_field_name][$language][0]['target_id']['#required'] = TRUE;
 
   // Management vertical tabs.
   $form['additional_settings'] = array(
@@ -448,11 +452,6 @@ function bat_event_edit_form_submit(&$form, &$form_state) {
 
   // Add the event to $form_state to be altered by other submit handlers.
   $form_state['event'] = $event;
-
-  $event_unit_reference = field_get_items('bat_event', $event, 'event_unit_reference');
-  if ($event_unit_reference !== FALSE) {
-    $unit_id = $event_unit_reference[0]['target_id'];
-  }
 
   $form_state['redirect'] = 'admin/bat/events';
 }

--- a/modules/bat_event/bat_event.api.php
+++ b/modules/bat_event/bat_event.api.php
@@ -19,8 +19,9 @@ function hook_bat_facets_search_results_alter(&$units, $context) {
  * Allow modules to define entity types that may be referenced by Bat Events
  * and provided to the BAT library as a Unit.
  *
- * NB: Entity types returned by this hook must have a
- * getEventDefaultValue method.
+ * NB: Entity types returned by this hook must implement the following methods:
+ *   * getEventDefaultValue
+ *   * formatEventValue
  *
  * @return array $entity_types
  *   Single-dimensional array with machine names of entity types.

--- a/modules/bat_event/bat_event.api.php
+++ b/modules/bat_event/bat_event.api.php
@@ -12,5 +12,19 @@
  * @param $context
  */
 function hook_bat_facets_search_results_alter(&$units, $context) {
-	unset($units[0]);
+  unset($units[0]);
+}
+
+/**
+ * Allow modules to define entity types that may be referenced by Bat Events
+ * and provided to the BAT library as a Unit.
+ *
+ * NB: Entity types returned by this hook must have a
+ * getEventDefaultValue method.
+ *
+ * @return array $entity_types
+ *   Single-dimensional array with machine names of entity types.
+ */
+function hook_bat_event_target_entity_types() {
+  return(array('bat_unit'));
 }

--- a/modules/bat_event/bat_event.install
+++ b/modules/bat_event/bat_event.install
@@ -192,6 +192,12 @@ function bat_event_schema() {
         'length' => 255,
         'not null' => FALSE,
       ),
+      'target_entity_type' => array(
+        'description' => 'The machine name of the target entity type for this event type.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => FALSE,
+      ),
     ),
     'primary key' => array('id'),
     'unique keys' => array(
@@ -304,5 +310,100 @@ function bat_event_update_7102() {
   foreach (bat_event_get_states() as $state) {
     $state['machine_name'] = $state['event_type'] . '_' . $state['id'];
     bat_event_save_state($state, $state['event_type']);
+  }
+}
+
+/**
+ * Add target entity type field and update existing event types.
+ */
+function bat_event_update_7103() {
+  $field = array(
+    'type' => 'varchar',
+    'not null' => FALSE,
+    'length' => 32,
+    'description' => 'The machine name of the target entity type for this event type.',
+  );
+  db_add_field('bat_event_type', 'target_entity_type', $field);
+
+  db_update('bat_event_type')
+    ->fields(array('target_entity_type' => 'bat_unit'))
+    ->execute();
+
+  // Copy data from the old field.
+  $old_name = 'event_unit_reference';
+  $new_name = 'event_bat_unit_reference';
+  $entity_type = 'bat_event';
+
+  // Get old field info.
+  $old_field = field_info_field($old_name);
+
+  // Create new field
+  $new_field = $old_field;
+  $new_field['field_name'] = $new_name;
+
+  if (!field_info_field($new_name)) {
+    field_create_field($new_field);
+  }
+  else {
+    field_update_field($new_field);
+  }
+
+  foreach(bat_event_get_types() as $bundle => $event_type) {
+    // Get old field instance.
+    $old_instance = field_info_instance($entity_type, $old_name, $bundle);
+
+    if ($old_instance) {
+      $new_instance = $old_instance;
+      $new_instance['field_name'] = $new_name;
+
+      if (!field_info_instance($entity_type, $new_name, $bundle)) {
+        field_create_instance($new_instance);
+      }
+      else {
+        field_update_instance($new_instance);
+      }
+
+      // Migrate old fields' data to the new ones
+      $field_data = db_select('field_data_' . $old_name, 'old')
+        ->fields('old')
+        ->condition('entity_type', $entity_type)
+        ->condition('bundle', $bundle)
+        ->execute();
+
+      while ($data = $field_data->fetchAssoc()) {
+        $data_new = array();
+        foreach ($data as $column => $value) {
+          $column = str_replace($old_name, $new_name, $column);
+          $data_new[$column] = $value;
+        }
+        db_insert('field_data_' . $new_name)
+          ->fields($data_new)
+          ->execute();
+      }
+
+      // Migrate old fields' revision data to the new ones.
+      $field_revision = db_select('field_revision_' . $old_name, 'old')
+        ->fields('old')
+        ->condition('entity_type', $entity_type)
+        ->condition('bundle', $bundle)
+        ->execute();
+
+      while ($revision = $field_revision->fetchAssoc()) {
+        $revision_new = array();
+        foreach ($revision as $column => $value) {
+          $column = str_replace($old_name, $new_name, $column);
+          $revision_new[$column] = $value;
+        }
+        db_insert('field_revision_' . $new_name)
+          ->fields($revision_new)
+          ->execute();
+      }
+
+      // Delete old instance
+      field_delete_instance($old_instance);
+
+      // Purge fields
+      field_purge_batch(1000);
+    }
   }
 }

--- a/modules/bat_event/bat_event.module
+++ b/modules/bat_event/bat_event.module
@@ -149,7 +149,7 @@ function bat_event_entity_info_alter(&$entity_info) {
 function bat_event_type_add_event_state_reference($entity) {
   field_info_cache_clear();
 
-  // "event_unit_reference" field.
+  // "event_state_reference" field.
   if (field_read_field('event_state_reference') === FALSE) {
     $field = array(
       'field_name' => 'event_state_reference',
@@ -163,7 +163,7 @@ function bat_event_type_add_event_state_reference($entity) {
 
   field_cache_clear();
 
-  // "event_unit_reference" field instance.
+  // "event_state_reference" field instance.
   if (field_read_instance('bat_event', 'event_state_reference', $entity->type) === FALSE) {
     $instance = array(
       'field_name' => 'event_state_reference',

--- a/modules/bat_event/bat_event.module
+++ b/modules/bat_event/bat_event.module
@@ -183,20 +183,25 @@ function bat_event_type_add_event_state_reference($entity) {
 }
 
 /**
- * Create a field of type 'Entity Reference' to reference a Bat Unit.
+ * Create fields of type 'Entity Reference' to reference the target entity.
+ *
+ * We need to create a field/instance for each possible target entity type.
  */
-function bat_event_type_add_unit_reference($entity) {
+function bat_event_type_add_target_entity_field($entity) {
   field_info_cache_clear();
 
-  // "event_unit_reference" field.
-  if (field_read_field('event_unit_reference') === FALSE) {
+  $entity_info = entity_get_info($entity->target_entity_type);
+  $field_name = 'event_' . $entity->target_entity_type . '_reference';
+
+  // field for this target entity type.
+  if (field_read_field($field_name) === FALSE) {
     $field = array(
-      'field_name' => 'event_unit_reference',
+      'field_name' => $field_name,
       'type' => 'entityreference',
       'cardinality' => 1,
       'locked' => 1,
       'settings' => array(
-        'target_type' => 'bat_unit',
+        'target_type' => $entity->target_entity_type,
       ),
     );
     field_create_field($field);
@@ -204,12 +209,12 @@ function bat_event_type_add_unit_reference($entity) {
 
   field_cache_clear();
 
-  // "event_unit_reference" field instance.
-  if (field_read_instance('bat_event', 'event_unit_reference', $entity->type) === FALSE) {
+  // field instance for this target entity type.
+  if (field_read_instance('bat_event', $field_name, $entity->type) === FALSE) {
     $instance = array(
-      'field_name' => 'event_unit_reference',
+      'field_name' => $field_name,
       'entity_type' => 'bat_event',
-      'label' => 'Unit',
+      'label' => $entity_info['label'],
       'bundle' => $entity->type,
       'required' => FALSE,
       'widget' => array(
@@ -1181,15 +1186,22 @@ class BatEventController extends EntityAPIController {
 
     $event_type = bat_event_type_load($entity->type);
 
+    // Construct target entity reference field name using this event type's target entity type.
+    $target_field_name = 'event_' . $event_type->target_entity_type . '_reference';
+
     // We are going to be updating the event - so the first step is to remove
     // the old event.
-    if ((!isset($entity->is_new)) && ($entity->original->start_date != '') && ($entity->original->end_date != '') &&
-        field_get_items('bat_event', $entity->original, 'event_unit_reference') !== FALSE) {
+    if ((!isset($entity->is_new)) &&
+        ($entity->original->start_date != '') &&
+        ($entity->original->end_date != '') &&
+        (field_get_items('bat_event', $entity->original, $target_field_name) !== FALSE)) {
 
-      $event_unit_reference = field_get_items('bat_event', $entity->original, 'event_unit_reference');
-      $unit_id = $event_unit_reference[0]['target_id'];
-      $bat_unit = bat_unit_load($unit_id);
-      $unit = new Unit($unit_id, $bat_unit->getEventDefaultValue($event_type->type));
+      // Get the referenced entity ID.
+      $event_target_entity_reference = field_get_items('bat_event', $entity->original, $target_field_name);
+      $target_entity_id = $event_target_entity_reference[0]['target_id'];
+      // Load the referenced entity.
+      $target_entity = entity_load_single($event_type->target_entity_type, $target_entity_id);
+      $unit = new Unit($target_entity_id, $target_entity->getEventDefaultValue($event_type->type));
 
       $this->batStoreSave($unit,
         new \DateTime($entity->original->start_date),
@@ -1204,9 +1216,8 @@ class BatEventController extends EntityAPIController {
 
     parent::save($entity);
 
-    // We have a unit defined so lets block availability there unless its a
-    // event that is to be deleted.
-    if (field_get_items('bat_event', $entity, 'event_unit_reference') !== FALSE) {
+    // Now we store the new event.
+    if (field_get_items('bat_event', $entity, $target_field_name) !== FALSE) {
 
       if (isset($event_type->default_event_value_field_ids[$entity->type])) {
         $field = $event_type->default_event_value_field_ids[$entity->type];
@@ -1230,10 +1241,10 @@ class BatEventController extends EntityAPIController {
         $event_value = $event_state_reference[0]['state_id'];
       }
 
-      $event_unit_reference = field_get_items('bat_event', $entity, 'event_unit_reference');
-      $unit_id = $event_unit_reference[0]['target_id'];
-      $bat_unit = bat_unit_load($unit_id);
-      $unit = new Unit($unit_id, $bat_unit->getEventDefaultValue($event_type->type));
+      $event_target_entity_reference = field_get_items('bat_event', $entity, $target_field_name);
+      $target_entity_id = $event_target_entity_reference[0]['target_id'];
+      $target_entity = entity_load_single($event_type->target_entity_type, $target_entity_id);
+      $unit = new Unit($target_entity_id, $target_entity->getEventDefaultValue($event_type->type));
 
       $this->batStoreSave($unit,
         new \DateTime($entity->start_date),
@@ -1288,17 +1299,22 @@ class BatEventController extends EntityAPIController {
   }
 
   public function deleteEvent($event) {
+    $event_type = bat_event_type_load($event->type);
+
+    // Construct target entity reference field name using this event type's target entity type.
+    $target_field_name = 'event_' . $event_type->target_entity_type . '_reference';
+
     // Check if the event had a unit associated with it and if so update the
     // availability calendar.
-    if (field_get_items('bat_event', $event, 'event_unit_reference') !== FALSE &&
+    if (field_get_items('bat_event', $event, $target_field_name) !== FALSE &&
         isset($event->start_date) && isset($event->end_date)) {
 
-      $event_unit_reference = field_get_items('bat_event', $event, 'event_unit_reference');
-      $unit_id = $event_unit_reference[0]['target_id'];
+      $event_target_entity_reference = field_get_items('bat_event', $entity->original, $target_field_name);
+      $target_entity_id = $event_target_entity_reference[0]['target_id'];
 
-      $bat_unit = bat_unit_load($unit_id);
-      $unit = new Unit($unit_id, $bat_unit->getEventDefaultValue($event->type));
-      $event_type = bat_event_type_load($event->type);
+      // Load the referenced entity.
+      $target_entity = entity_load_single($event_type->target_entity_type, $target_entity_id);
+      $unit = new Unit($target_entity_id, $target_entity->getEventDefaultValue($event->type));
 
       $this->batStoreSave($unit,
         clone($event->start_date_object),
@@ -1309,7 +1325,6 @@ class BatEventController extends EntityAPIController {
         $event->event_id,
         TRUE
       );
-
     }
   }
 
@@ -1361,7 +1376,7 @@ class BatEventTypeController extends EntityAPIControllerExportable {
       bat_event_create_event_type_schema($entity->type);
 
       // Create a field of type 'Entity Reference' to reference a Bat Unit.
-      bat_event_type_add_unit_reference($entity);
+      bat_event_type_add_target_entity_field($entity);
       if (isset($entity->fixed_event_states)) {
         if ($entity->fixed_event_states) {
           // Create a field of type 'Bat Event State Reference' to reference an Event State.

--- a/modules/bat_event/bat_event_type.admin.inc
+++ b/modules/bat_event/bat_event_type.admin.inc
@@ -90,6 +90,34 @@ function bat_event_type_form($form, &$form_state, $event_type, $op = 'edit') {
     '#default_value' => isset($event_type->event_granularity) ? $event_type->event_granularity : 'bat_daily',
   );
 
+  if (isset($event_type->is_new)) {
+    // Check for available Target Entity types.
+    $target_entity_types = module_invoke_all('bat_event_target_entity_types');
+    if (count($target_entity_types) == 1) {
+      // If there's only one target entity type, we simply store the value
+      // without showing it to the user.
+      $form['target_entity_type'] = array(
+        '#type' => 'value',
+        '#value' => $target_entity_types[0],
+      );
+    }
+    else {
+      // Build option list.
+      $options = array();
+      foreach ($target_entity_types as $target_entity_type) {
+        $target_entity_info = entity_get_info($target_entity_type);
+        $options[$target_entity_type] = $target_entity_info['label'];
+      }
+      $form['target_entity_type'] = array(
+        '#type' => 'select',
+        '#title' => t('Target Entity Type'),
+        '#description' => t('Select the target entity type for this Event type. In most cases you will wish to leave this as "Unit".'),
+        '#options' => $options,
+        // Default to BAT Unit if available.
+        '#default_value' => isset($target_entity_types['bat_unit']) ? 'bat_unit' : '',
+      );
+    }
+  }
 
   if (!isset($event_type->is_new) && $event_type->fixed_event_states == 0) {
     $fields_options = array();

--- a/modules/bat_event/views/bat_event.views_default.inc
+++ b/modules/bat_event/views/bat_event.views_default.inc
@@ -97,11 +97,6 @@ function bat_event_views_default_views() {
   $handler->display->display_options['relationships']['uid']['table'] = 'bat_events';
   $handler->display->display_options['relationships']['uid']['field'] = 'uid';
   $handler->display->display_options['relationships']['uid']['required'] = TRUE;
-  /* Relationship: Entity Reference: Referenced Entity */
-  $handler->display->display_options['relationships']['event_unit_reference_target_id']['id'] = 'event_unit_reference_target_id';
-  $handler->display->display_options['relationships']['event_unit_reference_target_id']['table'] = 'field_data_event_unit_reference';
-  $handler->display->display_options['relationships']['event_unit_reference_target_id']['field'] = 'event_unit_reference_target_id';
-  $handler->display->display_options['relationships']['event_unit_reference_target_id']['required'] = TRUE;
   /* Field: Events: Events ID */
   $handler->display->display_options['fields']['event_id']['id'] = 'event_id';
   $handler->display->display_options['fields']['event_id']['table'] = 'bat_events';
@@ -125,19 +120,6 @@ function bat_event_views_default_views() {
   $handler->display->display_options['fields']['end_date']['date_format'] = 'custom';
   $handler->display->display_options['fields']['end_date']['custom_date_format'] = 'd-m-Y H:i';
   $handler->display->display_options['fields']['end_date']['second_date_format'] = 'long';
-  /* Field: Events: Unit */
-  $handler->display->display_options['fields']['event_unit_reference']['id'] = 'event_unit_reference';
-  $handler->display->display_options['fields']['event_unit_reference']['table'] = 'field_data_event_unit_reference';
-  $handler->display->display_options['fields']['event_unit_reference']['field'] = 'event_unit_reference';
-  $handler->display->display_options['fields']['event_unit_reference']['settings'] = array(
-    'link' => 1,
-  );
-  /* Field: Units: Type_id */
-  $handler->display->display_options['fields']['type_id']['id'] = 'type_id';
-  $handler->display->display_options['fields']['type_id']['table'] = 'bat_units';
-  $handler->display->display_options['fields']['type_id']['field'] = 'type_id';
-  $handler->display->display_options['fields']['type_id']['relationship'] = 'event_unit_reference_target_id';
-  $handler->display->display_options['fields']['type_id']['label'] = 'Unit Type';
   /* Field: Events: Event Type */
   $handler->display->display_options['fields']['type']['id'] = 'type';
   $handler->display->display_options['fields']['type']['table'] = 'bat_events';
@@ -181,21 +163,6 @@ function bat_event_views_default_views() {
   $handler->display->display_options['filters']['event_id']['expose']['operator'] = 'event_id_op';
   $handler->display->display_options['filters']['event_id']['expose']['identifier'] = 'event_id';
   $handler->display->display_options['filters']['event_id']['expose']['remember_roles'] = array(
-    2 => '2',
-    1 => 0,
-    3 => 0,
-  );
-  /* Filter criterion: Events: Unit (event_unit_reference) */
-  $handler->display->display_options['filters']['event_unit_reference_target_id']['id'] = 'event_unit_reference_target_id';
-  $handler->display->display_options['filters']['event_unit_reference_target_id']['table'] = 'field_data_event_unit_reference';
-  $handler->display->display_options['filters']['event_unit_reference_target_id']['field'] = 'event_unit_reference_target_id';
-  $handler->display->display_options['filters']['event_unit_reference_target_id']['group'] = 1;
-  $handler->display->display_options['filters']['event_unit_reference_target_id']['exposed'] = TRUE;
-  $handler->display->display_options['filters']['event_unit_reference_target_id']['expose']['operator_id'] = 'event_unit_reference_target_id_op';
-  $handler->display->display_options['filters']['event_unit_reference_target_id']['expose']['label'] = 'Unit';
-  $handler->display->display_options['filters']['event_unit_reference_target_id']['expose']['operator'] = 'event_unit_reference_target_id_op';
-  $handler->display->display_options['filters']['event_unit_reference_target_id']['expose']['identifier'] = 'event_unit_reference_target_id';
-  $handler->display->display_options['filters']['event_unit_reference_target_id']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
     3 => 0,
@@ -245,22 +212,6 @@ function bat_event_views_default_views() {
   $handler->display->display_options['filters']['end_date']['expose']['operator'] = 'end_date_op';
   $handler->display->display_options['filters']['end_date']['expose']['identifier'] = 'end_date';
   $handler->display->display_options['filters']['end_date']['expose']['remember_roles'] = array(
-    2 => '2',
-    1 => 0,
-    3 => 0,
-  );
-  /* Filter criterion: Units: Type_id */
-  $handler->display->display_options['filters']['type_id']['id'] = 'type_id';
-  $handler->display->display_options['filters']['type_id']['table'] = 'bat_units';
-  $handler->display->display_options['filters']['type_id']['field'] = 'type_id';
-  $handler->display->display_options['filters']['type_id']['relationship'] = 'event_unit_reference_target_id';
-  $handler->display->display_options['filters']['type_id']['group'] = 1;
-  $handler->display->display_options['filters']['type_id']['exposed'] = TRUE;
-  $handler->display->display_options['filters']['type_id']['expose']['operator_id'] = 'type_id_op';
-  $handler->display->display_options['filters']['type_id']['expose']['label'] = 'Unit Type';
-  $handler->display->display_options['filters']['type_id']['expose']['operator'] = 'type_id_op';
-  $handler->display->display_options['filters']['type_id']['expose']['identifier'] = 'type_id';
-  $handler->display->display_options['filters']['type_id']['expose']['remember_roles'] = array(
     2 => '2',
     1 => 0,
     3 => 0,

--- a/modules/bat_fullcalendar/bat_fullcalendar.module
+++ b/modules/bat_fullcalendar/bat_fullcalendar.module
@@ -262,7 +262,11 @@ function bat_fullcalendar_ajax_event_status_change($form, $form_state) {
   $end_date->sub(new DateInterval('PT1M'));
   $event->end_date = $end_date->format('Y-m-d H:i');
 
-  $event->event_unit_reference[LANGUAGE_NONE][0]['target_id'] = $unit_id;
+  $event_type_entity = bat_event_type_load($event_type);
+  // Construct target entity reference field name using this event type's target entity type.
+  $target_field_name = 'event_' . $event_type_entity->target_entity_type . '_reference';
+  $event->{$target_field_name}[LANGUAGE_NONE][0]['target_id'] = $unit_id;
+
   $event->event_state_reference[LANGUAGE_NONE][0]['state_id'] = $state_id;
 
   $event->save();
@@ -302,7 +306,8 @@ function bat_fullcalendar_event_manager_form_submit($form, &$form_state) {
   $end_date->sub(new DateInterval('PT1M'));
   $event->end_date = $end_date->format('Y-m-d H:i');
 
-  $event->event_unit_reference[LANGUAGE_NONE][0]['target_id'] = $unit_id;
+  // TODO: genericize the event target entity?
+  $event->event_bat_unit_reference[LANGUAGE_NONE][0]['target_id'] = $unit_id;
   $event->{$field_name} = $form_state['values'][$field_name];
 
   $event->save();

--- a/modules/bat_fullcalendar/bat_fullcalendar.module
+++ b/modules/bat_fullcalendar/bat_fullcalendar.module
@@ -536,6 +536,7 @@ function bat_fullcalendar_configure($user_settings) {
       'resourceLabelText' => 'Rooms',
       'errorMessage' => t('Action not allowed. User may not have the right permissions.'),
       'businessHours' => $business_hours,
+      'selectConstraint' => NULL,
     );
 
     $settings['batCalendar'][$id] = array_replace_recursive($config, $user_setting);

--- a/modules/bat_fullcalendar/js/bat_fullcalendar_timeline.js
+++ b/modules/bat_fullcalendar/js/bat_fullcalendar_timeline.js
@@ -199,7 +199,7 @@ function saveBatEvent(event, revertFunc, calendars) {
         $.ajax({
           type: "PUT",
           url: events_url + '/' + event.bat_id,
-          data: JSON.stringify({start_date: event.start.format('YYYY-MM-DD HH:mm'), end_date: event.end.format('YYYY-MM-DD HH:mm'), unit_id: unit_id}),
+          data: JSON.stringify({start_date: event.start.format('YYYY-MM-DD HH:mm'), end_date: event.end.format('YYYY-MM-DD HH:mm'), target_id: unit_id}),
           dataType: 'json',
           beforeSend: function (request) {
             request.setRequestHeader("X-CSRF-Token", token);

--- a/modules/bat_fullcalendar/js/bat_fullcalendar_timeline.js
+++ b/modules/bat_fullcalendar/js/bat_fullcalendar_timeline.js
@@ -157,7 +157,7 @@ function saveBatEvent(event, revertFunc, calendars) {
   var unit_id = event.resourceId.substring(1);
 
   // Retrieve all events for the unit and time we're dragging onto.
-  var events_url = '/bat/v2/events?unit_ids=' + unit_id + '&start_date=' + event.start.format('YYYY-MM-DD HH:mm') +
+  var events_url = '/bat/v2/events?target_ids=' + unit_id + '&target_entity_type=bat_unit&start_date=' + event.start.format('YYYY-MM-DD HH:mm') +
                    '&end_date=' + event.end.format('YYYY-MM-DD HH:mm') + '&event_types=' + event.type;
   proceed = true;
   jQuery.ajax({

--- a/modules/bat_fullcalendar/js/bat_fullcalendar_timeline.js
+++ b/modules/bat_fullcalendar/js/bat_fullcalendar_timeline.js
@@ -33,7 +33,7 @@ Drupal.behaviors.bat_event = {
         },
         businessHours: Drupal.settings.batCalendar[0].businessHours,
         defaultView: Drupal.settings.batCalendar[0].defaultView,
-        selectConstraint: 'businessHours',
+        selectConstraint: Drupal.settings.batCalendar[0].selectConstraint,
         views: {
           timelineDay: {
             buttonText: Drupal.settings.batCalendar[0].viewsTimelineDayButtonText,

--- a/modules/bat_fullcalendar/src/FullCalendarOpenStateEventFormatter.php
+++ b/modules/bat_fullcalendar/src/FullCalendarOpenStateEventFormatter.php
@@ -37,15 +37,18 @@ class FullCalendarOpenStateEventFormatter extends AbstractEventFormatter {
   public function format(EventInterface $event) {
     $editable = FALSE;
 
-    // Load the unit entity from Drupal
-    $bat_unit = bat_unit_load($event->getUnitId());
+    $bat_event = bat_event_load($event->getValue());
+    if ($bat_event) {
+      $event_type = bat_event_type_load($bat_event->type);
 
-    // Get the unit entity default value
-    $default_value = $bat_unit->getEventDefaultValue($this->event_type->type);
+      // Load the target entity from Drupal
+      $target_entity = entity_load_single($event_type->target_entity_type, $event->getUnitId());
+
+      // Get the target entity default value
+      $default_value = $target_entity->getEventDefaultValue($this->event_type->type);
+    }
 
     if ($event->getValue()) {
-      $bat_event = bat_event_load($event->getValue());
-
       // Change the default value to the one that the event actually stores in the entity
       $default_value = $bat_event->getEventValue();
 
@@ -57,11 +60,13 @@ class FullCalendarOpenStateEventFormatter extends AbstractEventFormatter {
     $formatted_event = array(
       'start' => $event->startYear() . '-' . $event->startMonth('m') . '-' . $event->startDay('d') . 'T' . $event->startHour('H') . ':' . $event->startMinute() . ':00Z',
       'end' => $event->endYear() . '-' . $event->endMonth('m') . '-' . $event->endDay('d') . 'T' . $event->endHour('H') . ':' . $event->endMinute() . ':00Z',
-      'title' => $bat_unit->formatEventValue($this->event_type->type, $default_value),
       'blocking' => 0,
       'fixed' => 0,
       'editable' => $editable,
     );
+    if ($bat_event) {
+      $formatted_event['title'] = $target_entity->formatEventValue($this->event_type->type, $default_value);
+    }
 
     if ($event->getValue() < 100) {
       $formatted_event['color']  = 'orange';

--- a/modules/bat_unit/bat_unit.module
+++ b/modules/bat_unit/bat_unit.module
@@ -405,6 +405,22 @@ function bat_unit_menu_local_tasks_alter(&$data, $router_item, $root_path) {
 
 
 /**
+ * @section Bat Hooks
+ *
+ * Bat Integration.
+ */
+
+/**
+ * Implements hook_bat_event_target_entity_types()
+ *
+ * Register BAT Unit as a BAT event target entity type.
+ */
+function bat_unit_bat_event_target_entity_types() {
+  return(array('bat_unit'));
+}
+
+
+/**
  * @section Bat Unit
  *
  * The following code deals with Bat Units and their bundles. (entity types)


### PR DESCRIPTION
Ok @istos here it is - event creation/editing etc works on the standard forms for events referencing units or rates, works with scheduler when referencing units. (existing functionality)

2 weaknesses:
- the 'All events' view was modified to remove anything to do with a unit. Perhaps we should re-name the view to 'All unit events' and re-instate the functionality? Confusing for people using the base functionality.
- bat_fullcalendar has been modified to work, but everything still assumes Units. Do we anticipate building other interfaces for any non-unit use cases, or should we try to make the basic interface agnostic about what kind of entity events relate to?
